### PR TITLE
выполнено дз 8

### DIFF
--- a/Navigation/CollectionPhotos/PhotosViewController.swift
+++ b/Navigation/CollectionPhotos/PhotosViewController.swift
@@ -13,8 +13,15 @@ class PhotosViewController: UIViewController {
         case `default` = "collectionViewCell"
     }
     
-    let imagePublisher = ImagePublisherFacade()
-    var photoModel: [UIImage] = []
+    let imagePublisher = ImageProcessor()
+    
+    private let photoPreModel: [UIImage] = {
+       let photosNameArr =  Photos().createMockPhotos()
+        return photosNameArr.map { photo in
+            UIImage(named: photo.name)!
+        }
+    }()
+    var photoModel:[UIImage] = []
     let collectionView: UICollectionView = {
         let collection = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collection.translatesAutoresizingMaskIntoConstraints = false
@@ -24,15 +31,23 @@ class PhotosViewController: UIViewController {
     
     private let sectionInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
     private let itemsPerRow: CGFloat = 3
-    
-    deinit {
-        imagePublisher.removeSubscription(for: self)
-    }
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        imagePublisher.subscribe(self)
-        imagePublisher.addImagesWithTimer(time: 1, repeat: 30)
+        let stDate = Date.now
+        let qos = QualityOfService.allCases.randomElement()!
+        imagePublisher.processImagesOnThread(sourceImages: photoPreModel, filter: ColorFilter.allCases.randomElement()!, qos: qos) { filteredImage in
+            for image in filteredImage {
+                guard let image = image else { return }
+                self.photoModel.append(UIImage(cgImage: image))
+                DispatchQueue.main.async {
+                    self.collectionView.reloadData()
+                }
+            }
+            let fnDate = Date.now
+            let distance = round(stDate.distance(to: fnDate) * 10 / 10.0)
+            print("Start \(stDate.ISO8601Format()) | finish \(fnDate.ISO8601Format()) with \(qos.rawValue) distance \(distance)")
+        }
         navigationItem.title = "Photo Gallery"
         navigationController?.navigationBar.prefersLargeTitles = false
         view.backgroundColor = .white
@@ -96,13 +111,5 @@ extension PhotosViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return sectionInsets.left
-    }
-}
-
-extension PhotosViewController: ImageLibrarySubscriber {
-    
-    func receive(images: [UIImage]){
-        photoModel = images
-        collectionView.reloadData()
     }
 }

--- a/Navigation/extention/Extention.swift
+++ b/Navigation/extention/Extention.swift
@@ -38,7 +38,13 @@ extension UIView {
     }
 }
 
-
+extension QualityOfService: CaseIterable {
+    public static var allCases: [QualityOfService] {
+        return [.userInteractive, .background, .utility , .userInitiated, .default]
+    }
+    
+    
+}
 
 
      


### PR DESCRIPTION
При  печати времени применения фильтров на 20 картинок и видно что назначение более высокого приоритета не всегда дает прибавку к скорости выполнения. На лицо инверсия приоритетов
Start 2022-02-01T14:41:33Z | finish 2022-02-01T14:41:34Z with 17 distance 2.0
Start 2022-02-01T14:41:38Z | finish 2022-02-01T14:41:39Z with 25 distance 1.0
Start 2022-02-01T14:41:43Z | finish 2022-02-01T14:41:45Z with 17 distance 1.0
Start 2022-02-01T14:41:49Z | finish 2022-02-01T14:41:50Z with 33 distance 1.0
Start 2022-02-01T14:41:54Z | finish 2022-02-01T14:41:58Z with 9 distance 4.0
Start 2022-02-01T14:42:02Z | finish 2022-02-01T14:42:03Z with 17 distance 1.0
Start 2022-02-01T14:42:06Z | finish 2022-02-01T14:42:07Z with -1 distance 1.0
Start 2022-02-01T14:42:11Z | finish 2022-02-01T14:42:12Z with 33 distance 1.0
Start 2022-02-01T14:42:15Z | finish 2022-02-01T14:42:16Z with 33 distance 1.0
Start 2022-02-01T14:42:20Z | finish 2022-02-01T14:42:22Z with 33 distance 2.0
Start 2022-02-01T14:42:28Z | finish 2022-02-01T14:42:29Z with 17 distance 1.0
